### PR TITLE
Make sure p1_sha isn't compiled to native code

### DIFF
--- a/src/p1_sha.erl
+++ b/src/p1_sha.erl
@@ -25,6 +25,8 @@
 
 -author('alexey@process-one.net').
 
+-compile(no_native).
+
 -export([load_nif/0,
          sha/1, sha1/1, sha224/1, sha256/1,
          sha384/1, sha512/1, to_hexlist/1]).


### PR DESCRIPTION
NIFs [cannot](http://erlang.org/pipermail/erlang-questions/2011-June/059237.html) be loaded from a HiPE-compiled module.
