### PR TITLE
Deprecate hash functions in favor of crypto:hash/2

### DIFF
--- a/c_src/p1_sha.c
+++ b/c_src/p1_sha.c
@@ -16,111 +16,11 @@
  */
 
 #include <erl_nif.h>
-#include <string.h>
 #include <stdio.h>
-#include <openssl/sha.h>
-
-#define SHA1_T 1
-#define SHA224_T 224
-#define SHA256_T 256
-#define SHA384_T 384
-#define SHA512_T 512
 
 static int load(ErlNifEnv* env, void** priv, ERL_NIF_TERM load_info)
 {
     return 0;
-}
-
-static int convert(ErlNifEnv* env, int argc,
-		   const ERL_NIF_TERM argv[],
-		   int type, ErlNifBinary *out)
-{
-    ErlNifBinary in;
-    int res = 0;
-    
-    if (argc == 1) {
-	if (enif_inspect_iolist_as_binary(env, argv[0], &in)) {
-	    switch (type) {
-	    case SHA1_T:
-		res = enif_alloc_binary(SHA_DIGEST_LENGTH, out);
-		if (res) SHA1(in.data, in.size, out->data);
-		break;
-	    case SHA224_T:
-		res = enif_alloc_binary(SHA224_DIGEST_LENGTH, out);
-		if (res) SHA224(in.data, in.size, out->data);
-		break;
-	    case SHA256_T:
-		res = enif_alloc_binary(SHA256_DIGEST_LENGTH, out);
-		if (res) SHA256(in.data, in.size, out->data);
-		break;
-	    case SHA384_T:
-		res = enif_alloc_binary(SHA384_DIGEST_LENGTH, out);
-		if (res) SHA384(in.data, in.size, out->data);
-		break;
-	    case SHA512_T:
-		res = enif_alloc_binary(SHA512_DIGEST_LENGTH, out);
-		if (res) SHA512(in.data, in.size, out->data);
-		break;
-	    }
-	}
-    }
-
-    return res;
-}
-
-static ERL_NIF_TERM sha1(ErlNifEnv* env, int argc,
-			 const ERL_NIF_TERM argv[])
-{
-    ErlNifBinary out;
-
-    if (convert(env, argc, argv, SHA1_T, &out))
-	return enif_make_binary(env, &out);
-    else
-	return enif_make_badarg(env);
-}
-
-static ERL_NIF_TERM sha224(ErlNifEnv* env, int argc,
-			   const ERL_NIF_TERM argv[])
-{
-    ErlNifBinary out;
-
-    if (convert(env, argc, argv, SHA224_T, &out))
-	return enif_make_binary(env, &out);
-    else
-	return enif_make_badarg(env);
-}
-
-static ERL_NIF_TERM sha256(ErlNifEnv* env, int argc,
-			   const ERL_NIF_TERM argv[])
-{
-    ErlNifBinary out;
-
-    if (convert(env, argc, argv, SHA256_T, &out))
-	return enif_make_binary(env, &out);
-    else
-	return enif_make_badarg(env);
-}
-
-static ERL_NIF_TERM sha384(ErlNifEnv* env, int argc,
-			   const ERL_NIF_TERM argv[])
-{
-    ErlNifBinary out;
-
-    if (convert(env, argc, argv, SHA384_T, &out))
-	return enif_make_binary(env, &out);
-    else
-	return enif_make_badarg(env);
-}
-
-static ERL_NIF_TERM sha512(ErlNifEnv* env, int argc,
-			   const ERL_NIF_TERM argv[])
-{
-    ErlNifBinary out;
-
-    if (convert(env, argc, argv, SHA512_T, &out))
-	return enif_make_binary(env, &out);
-    else
-	return enif_make_badarg(env);
 }
 
 static ERL_NIF_TERM to_hexlist(ErlNifEnv* env, int argc,
@@ -147,11 +47,6 @@ static ERL_NIF_TERM to_hexlist(ErlNifEnv* env, int argc,
 
 static ErlNifFunc nif_funcs[] =
     {
-	{"sha1", 1, sha1},
-	{"sha224", 1, sha224},
-	{"sha256", 1, sha256},
-	{"sha384", 1, sha384},
-	{"sha512", 1, sha512},
 	{"to_hexlist", 1, to_hexlist}
     };
 

--- a/src/p1_sha.erl
+++ b/src/p1_sha.erl
@@ -27,9 +27,12 @@
 
 -compile(no_native).
 
--export([load_nif/0,
-         sha/1, sha1/1, sha224/1, sha256/1,
-         sha384/1, sha512/1, to_hexlist/1]).
+-export([load_nif/0, sha/1, to_hexlist/1]).
+
+%% The following functions are deprecated.
+-export([sha1/1, sha224/1, sha256/1, sha384/1, sha512/1]).
+
+-deprecated([{sha1,1}, {sha224,1}, {sha256,1}, {sha384,1}, {sha512,1}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -65,22 +68,22 @@ to_hexlist(_Text) ->
     erlang:nif_error(nif_not_loaded).
 
 sha(Text) ->
-    to_hexlist(sha1(Text)).
+    to_hexlist(crypto:hash(sha, Text)).
 
-sha1(_Text) ->
-    erlang:nif_error(nif_not_loaded).
+sha1(Text) ->
+    crypto:hash(sha, Text).
 
-sha224(_Text) ->
-    erlang:nif_error(nif_not_loaded).
+sha224(Text) ->
+    crypto:hash(sha224, Text).
 
-sha256(_Text) ->
-    erlang:nif_error(nif_not_loaded).
+sha256(Text) ->
+    crypto:hash(sha256, Text).
 
-sha384(_Text) ->
-    erlang:nif_error(nif_not_loaded).
+sha384(Text) ->
+    crypto:hash(sha384, Text).
 
-sha512(_Text) ->
-    erlang:nif_error(nif_not_loaded).
+sha512(Text) ->
+    crypto:hash(sha512, Text).
 
 %%%===================================================================
 %%% Unit tests


### PR DESCRIPTION
Use crypto:hash/2 function instead of ones from p1_sha.

This function exists since commit
erlang/otp@208f9ad3828313f6c659a501d53f5534ec1bdf2e and also implemented
as NIF, so I believe it's safe to use it.

See also this PR:

* processone/ejabberd#1539

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>