### PR TITLE
ECDH curve auto-selection.

### DIFF
--- a/c_src/fast_tls.c
+++ b/c_src/fast_tls.c
@@ -376,17 +376,10 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx) {
 #ifndef OPENSSL_NO_ECDH
 
 static void setup_ecdh(SSL_CTX *ctx) {
-    EC_KEY *ecdh;
-
     if (SSLeay() < 0x1000005fL) {
         return;
     }
-
-    ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-    SSL_CTX_set_options(ctx, SSL_OP_SINGLE_ECDH_USE);
-    SSL_CTX_set_tmp_ecdh(ctx, ecdh);
-
-    EC_KEY_free(ecdh);
+    SSL_CTX_set_ecdh_auto(ctx, 1);
 }
 
 #endif


### PR DESCRIPTION
Should fix #20

Since openssl 1.0.2 there is no need to hard-code the curves.

Cf. https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_ecdh_auto.html#NOTES:
> The functions SSL_CTX_set_ecdh_auto() and SSL_set_ecdh_auto() can be used to
> make a server always choose the most appropriate curve for a client.