### PR TITLE
Fix crash on Mac OS X High Sierra

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,8 @@
 
 {erl_opts, [debug_info, {src_dirs, ["src"]}]}.
 
-{port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lssl -lcrypto"}]}.
+{port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lssl -lcrypto"},
+            {"darwin", "DRV_LDFLAGS", "-bundle -bundle_loader ${BINDIR}/beam.smp $ERL_LDFLAGS"}]}.
 
 {port_specs, [{"priv/lib/fast_tls.so", ["c_src/fast_tls.c", "c_src/hashmap.c"]},
               {"priv/lib/p1_sha.so", ["c_src/p1_sha.c"]}]}.


### PR DESCRIPTION
Fix crash on Mac OS X High Sierra due to replacement of system OpenSSL with BoringSSL by building fast_tls with a two-level namespace (instead of single-level flat namespace that rebar defaults to)

See also https://bugs.erlang.org/browse/ERL-439

Fixes fast_tls issue #27