### PR TITLE
fix macOS compilation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,6 +23,9 @@
 {erl_opts, [debug_info, {src_dirs, ["src"]}]}.
 
 {port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lssl -lcrypto"},
+            %% OS X
+            {"darwin.*-64$", "CFLAGS", "-I/usr/local/opt/openssl/include -m64 $CFLAGS"},
+            {"darwin.*-64$", "LDFLAGS", "-L/usr/local/opt/openssl/lib -arch x86_64 $LDFLAGS"},
             {"darwin", "DRV_LDFLAGS", "-bundle -bundle_loader ${BINDIR}/beam.smp $ERL_LDFLAGS"}]}.
 
 {port_specs, [{"priv/lib/fast_tls.so", ["c_src/fast_tls.c"]},


### PR DESCRIPTION
This will fix compile error on macOS (any version):

```
[...]
Compiling fast_tls/c_src/fast_tls.c
fast_tls/c_src/fast_tls.c:21:10: fatal error: 'openssl/err.h' file not found
#include <openssl/err.h>
         ^~~~~~~~~~~~~~~
1 error generated.
ERROR: compile failed while processing fast_tls: rebar_abort
```