### PR TITLE
Escape bundle_loader path

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 {erl_opts, [debug_info, {src_dirs, ["src"]}]}.
 
 {port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS -lssl -lcrypto"},
-            {"darwin", "DRV_LDFLAGS", "-bundle -bundle_loader ${BINDIR}/beam.smp $ERL_LDFLAGS"}]}.
+            {"darwin", "DRV_LDFLAGS", "-bundle -bundle_loader \"${BINDIR}/beam.smp\" $ERL_LDFLAGS"}]}.
 
 {port_specs, [{"priv/lib/fast_tls.so", ["c_src/fast_tls.c"]},
               {"priv/lib/p1_sha.so", ["c_src/p1_sha.c"]}]}.


### PR DESCRIPTION
It allows to compile with Erlang, installed into a directory with whitespaces.

ErlangInstaller on Mac OS X installs erlang into a path like:

```
/Users/username/Library/Application Support/ErlangInstaller/21.1/bin
```

Which does not work well with fast_tls compilation :)