### PR TITLE
Client certificate requirements

### DIFF
--- a/src/fast_tls.erl
+++ b/src/fast_tls.erl
@@ -483,9 +483,15 @@ load_nif_test() ->
     SOPath = p1_nif_utils:get_so_path(fast_tls, [], "fast_tls"),
     ?assertEqual(ok, load_nif(SOPath)).
 
-transmission_test() ->
-    {LPid, Port} = setup_listener([]),
-    SPid = setup_sender(Port, []),
+transmission_with_client_certificate_test() ->
+    transmission_test_with_opts([], [{certfile, <<"../tests/cert.pem">>}]).
+
+transmission_without_client_certificate_test() ->
+    transmission_test_with_opts([], []).
+
+transmission_test_with_opts(ListenerOpts, SenderOpts) ->
+    {LPid, Port} = setup_listener(ListenerOpts),
+    SPid = setup_sender(Port, SenderOpts),
     SPid ! {stop, self()},
     receive
         {result, Res} ->
@@ -553,7 +559,7 @@ setup_sender(Port, Opts) ->
         binary, {packet, 0}, {active, false},
         {reuseaddr, true}, {nodelay, true}]),
     spawn(fun() ->
-        {ok, TLSSock} = tcp_to_tls(Socket, [connect, {certfile, <<"../tests/cert.pem">>} | Opts]),
+        {ok, TLSSock} = tcp_to_tls(Socket, [connect | Opts]),
         sender_loop(TLSSock)
           end).
 

--- a/src/fast_tls.erl
+++ b/src/fast_tls.erl
@@ -153,7 +153,7 @@ tcp_to_tls(TCPSocket, Options) ->
                   false -> ?SET_CERTIFICATE_FILE_ACCEPT
               end,
     CertFile = proplists:get_value(certfile, Options, ""),
-    if CertFile /= [] orelse Command == ?SET_CERTIFICATE_FILE_ACCEPT ->
+    if CertFile /= [] orelse Command == ?SET_CERTIFICATE_FILE_CONNECT ->
         Flags1 = case lists:member(verify_none, Options) of
                      true -> ?VERIFY_NONE;
                      false -> 0


### PR DESCRIPTION
We're making a wrong check here.
```erlang
     if CertFile /= [] orelse Command == ?SET_CERTIFICATE_FILE_ACCEPT ->
```
meant that in order to proceed, if no certificate file was provided, then at least the command should be an accept one. Which is not correct. In TLS we require the server, the one who does accept, to provide a certificate, while the client is not usually required so. It should instead be required for the server. I also divided the original test in two versions, to check that both are passing, and added a check to make sure that the server can see this certificate when the client offers so.