### PR TITLE
Plus road

### DIFF
--- a/src/fast_tls.erl
+++ b/src/fast_tls.erl
@@ -37,7 +37,8 @@
          get_peer_certificate/1, get_peer_certificate/2,
          get_verify_result/1, get_cert_verify_string/2,
          add_certfile/2, get_certfile/1, delete_certfile/1,
-         clear_cache/0, get_negotiated_cipher/1]).
+         clear_cache/0, get_negotiated_cipher/1,
+         get_tls_last_message/2]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -103,6 +104,12 @@ clear_cache_nif() ->
     erlang:nif_error({nif_not_loaded, ?MODULE}).
 
 get_negotiated_cipher_nif(_Port) ->
+    erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+tls_get_peer_finished_nif(_Port) ->
+    erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+tls_get_finished_nif(_Port) ->
     erlang:nif_error({nif_not_loaded, ?MODULE}).
 
 %%% --------------------------------------------------------
@@ -308,8 +315,13 @@ get_negotiated_cipher(#tlssock{tlsport = Port}) ->
             error
     end.
 
--spec get_verify_result(tls_socket()) -> byte().
+-spec get_tls_last_message(peer | self, tls_socket()) -> binary().
+get_tls_last_message(peer, #tlssock{tlsport = Port}) ->
+    tls_get_peer_finished_nif(Port);
+get_tls_last_message(self, #tlssock{tlsport = Port}) ->
+    tls_get_finished_nif(Port).
 
+-spec get_verify_result(tls_socket()) -> byte().
 get_verify_result(#tlssock{tlsport = Port}) ->
     {ok, Res} = get_verify_result_nif(Port),
     Res.

--- a/src/fast_tls.erl
+++ b/src/fast_tls.erl
@@ -315,7 +315,7 @@ get_negotiated_cipher(#tlssock{tlsport = Port}) ->
             error
     end.
 
--spec get_tls_last_message(peer | self, tls_socket()) -> binary().
+-spec get_tls_last_message(peer | self, tls_socket()) -> {ok, binary()} | {error, term()}.
 get_tls_last_message(peer, #tlssock{tlsport = Port}) ->
     tls_get_peer_finished_nif(Port);
 get_tls_last_message(self, #tlssock{tlsport = Port}) ->


### PR DESCRIPTION
As described in the commit message:
```
This is what is needed to be able to implement the `tls-unique` variant
of channel binding. For documentation, read:

RFC5056: On the Use of Channel Bindings to Secure Channels:
https://tools.ietf.org/html/rfc5056

RFC5929: Channel Bindings for TLS: https://tools.ietf.org/html/rfc5929

https://www.iana.org/assignments/channel-binding-types/channel-binding-types.xhtml

RFC5802, Section 6: Salted Challenge Response Authentication Mechanism
(SCRAM) SASL and GSS-API Mechanisms, Channel Binding:
https://tools.ietf.org/html/rfc5802#section-6
```