### PR TITLE
Update hex packaged files

### DIFF
--- a/src/fast_tls.app.src
+++ b/src/fast_tls.app.src
@@ -31,7 +31,7 @@
      %% hex.pm packaging:
      {files, ["src/", "c_src/fast_tls.c", "c_src/uthash.h",
               "c_src/options.h", "c_src/p1_sha.c", "c_src/stdint.h",
-              "c_src/ioqueue.h", "c_src/ioqueue.c",
+              "c_src/ioqueue.h", "c_src/ioqueue.c", "configure", "vars.config.in",
               "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt"]},
      {licenses, ["Apache 2.0"]},
      {links, [{"Github", "https://github.com/processone/fast_tls"}]}]}.


### PR DESCRIPTION
'configure' and 'vars.config.in' are required to build as ejabberd
dependencies with rebar3