### PR TITLE
Make parameterizable the rebar binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
+REBAR ?= rebar
+
 all: src
 
 src:
-	rebar get-deps compile
+	$(REBAR) get-deps compile
 
 clean:
-	rebar clean
+	$(REBAR) clean
 
 test:
-	rebar skip_deps=true eunit
+	$(REBAR) skip_deps=true eunit
 
 .PHONY: clean src


### PR DESCRIPTION
Define the REBAR variable by a conditional assignment doesn't change the behavior of this Makefile but allows a package manager to explicity set the full path of the rebar binary.