### PR TITLE
Support LibreSSL >= 3.5 (opaque structs)

### DIFF
--- a/c_src/fast_tls.c
+++ b/c_src/fast_tls.c
@@ -61,7 +61,7 @@ typedef unsigned __int32 uint32_t;
 #define SSL_OP_NO_TICKET 0
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x30500000L)
 #define DH_set0_pqg(dh, dh_p, param, dh_g) (dh)->p = dh_p; (dh)->g = dh_g
 #endif
 


### PR DESCRIPTION
Hi,

This PR adds support for the next version of LibreSSL (3.5) that is scheduled for release on OpenBSD 7.1. This LibreSSL version [adopts the struct visibility changes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.0-relnotes.txt) that were introduced in OpenSSL 1.1, and fast_tls fails to compile as it assumes the struct fields are still public.

With this change fast_tls builds successfully on the latest OpenBSD snapshot.