### PR TITLE
OpenSSL 3 compatibility

### DIFF
--- a/c_src/fast_tls.c
+++ b/c_src/fast_tls.c
@@ -1265,6 +1265,7 @@ static ERL_NIF_TERM set_fips_mode_nif(ErlNifEnv *env, int argc,
   if (!enif_get_int(env, argv[0], &enable))
     return enif_make_badarg(env);
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   int fips_mode = FIPS_mode();
 
   if ((fips_mode == 0 && enable != 0) ||
@@ -1273,6 +1274,9 @@ static ERL_NIF_TERM set_fips_mode_nif(ErlNifEnv *env, int argc,
 
   if (ret != 1)
     return ssl_error(env, "FIPS_mode_set() failed");
+#else
+#warning OpenSSL 3 FIPS support not implemented
+#endif
 
   return enif_make_atom(env, "ok");
 }
@@ -1280,7 +1284,12 @@ static ERL_NIF_TERM set_fips_mode_nif(ErlNifEnv *env, int argc,
 static ERL_NIF_TERM get_fips_mode_nif(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]) {
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   const char *ret = FIPS_mode() ? "true" : "false";
+#else
+#warning OpenSSL 3 FIPS support not implemented
+  static const char *ret = "false";
+#endif
 
   return enif_make_atom(env, ret);
 }


### PR DESCRIPTION
The function calls 'FIPS_mode()' and 'FIPS_mode_set()' have been removed from OpenSSL 3.0

The (newly added in #54) FIPS mode support will need to be rewritten to work in OpenSSL 3.0, see: [https://wiki.openssl.org/index.php/OpenSSL_3.0#Using_the_FIPS_Module_in_applications](https://wiki.openssl.org/index.php/OpenSSL_3.0#Using_the_FIPS_Module_in_applications)

This PR allows previous functionality to continue working without FIPS mode support.