### PR TITLE
Fix build failure with LibreSSL

### DIFF
--- a/c_src/fast_tls.c
+++ b/c_src/fast_tls.c
@@ -72,6 +72,10 @@ typedef unsigned __int32 uint32_t;
 #define DH_set0_pqg(dh, dh_p, param, dh_g) (dh)->p = dh_p; (dh)->g = dh_g
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#define SSL_get_extms_support(s) 0
+#endif
+
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
 #define SSL_is_server(s) (s)->server
 #endif


### PR DESCRIPTION
The library can't be compiled with LibreSSL
since 1dc4ac9a0ca4a7e0ef026194a1ce56b45db6fe8d

RFC 7627 APIs were introduced in OpenSSL 1.1.0. This quick fix replaces
SSL_get_extms_support with a macro in versions that don't have it.

---

I license this contribution under the terms set out in the Unlicense
license.